### PR TITLE
Avoid logging huge datasets to console

### DIFF
--- a/lib/Teradata.js
+++ b/lib/Teradata.js
@@ -78,7 +78,6 @@ Teradata = {
                 return asyncResultSet.toObjArrayAsync();
             })
             .then(function (resultSetArray) {
-                console.log(resultSetArray);
                 return resultSetArray;
             })
     },


### PR DESCRIPTION
In the future the `verbose` option will allow to print out datasets for all your queries.
