### PR TITLE
Enable JDBC connection options specification

### DIFF
--- a/lib/Teradata.js
+++ b/lib/Teradata.js
@@ -9,29 +9,41 @@ var DEFAUT_OPTIONS = {
     verbose: false
 };
 var teradataInstance;
-var teradataConfig = {properties: {}};
+var teradataConfig = {
+    properties: {}
+};
 var tdConn;
 var verboseLoggingOn = DEFAUT_OPTIONS.verbose;
+
 function createPromisedStatement(query) {
     return tdConn.conn.createStatementAsync()
-        .then(function (statement) {
+        .then(function(statement) {
             queryStatement = Promise.promisifyAll(statement);
             return queryStatement;
         })
 }
+
 function createPromisedPreparedStatement(query) {
     return tdConn.conn.prepareStatementAsync(query)
-        .then(function (statement) {
+        .then(function(statement) {
             queryStatement = Promise.promisifyAll(statement);
             return queryStatement;
         })
 }
 Teradata = {
-    connect: function (url, user, password, options) {
+    connect: function(url, user, password, options, jdbcOptions) {
         //config using user settings
         teradataConfig.url = url;
         teradataConfig.properties.user = user;
         teradataConfig.properties.password = password;
+
+        // marshall node-jdbc options into config for creating the teradata jdbc connection
+        if (jdbcOptions) {
+            for (var option in jdbcOptions) {
+                teradataConfig[option] = jdbcOptions[option];
+            }
+        }
+        
         var teradataJarPath = options && options.teradataJarPath ? options.teradataJarPath : DEFAUT_OPTIONS.teradataJarPath;
         verboseLoggingOn = options && options.verbose === true ? true : false;
 
@@ -50,14 +62,14 @@ Teradata = {
         teradataInstance = Promise.promisifyAll(new jdbc(teradataConfig));
 
         return teradataInstance.initializeAsync()
-            .then(function () {
-                if (verboseLoggingOn===true) {
+            .then(function() {
+                if (verboseLoggingOn === true) {
                     chalksay.green("Succesfully initialized Teradata connection to %s ", teradataConfig.url);
                 }
                 return teradataInstance.reserveAsync();
             })
-            .then(function (teradataConnection) {
-                if (verboseLoggingOn===true) {
+            .then(function(teradataConnection) {
+                if (verboseLoggingOn === true) {
                     chalksay.green("Teradata connected and ready for queries");
                 }
                 tdConn = teradataConnection;
@@ -66,78 +78,78 @@ Teradata = {
             })
     },
 
-    disconnect: function () {
+    disconnect: function() {
         return teradataInstance.releaseAsync(tdConn)
-            .then(function () {
-                if (verboseLoggingOn===true) {
+            .then(function() {
+                if (verboseLoggingOn === true) {
                     chalksay.green("Teradata database disconnected");
                 }
                 return true;
             });
     },
 
-    executeQuery: function (query, fetchSize) {
+    executeQuery: function(query, fetchSize) {
         var queryFetchSize = fetchSize ? fetchSize : DEFAULT_FETCH_SIZE;
         var queryStatement;
         return createPromisedStatement(query)
-            .then(function (statement) {
+            .then(function(statement) {
                 queryStatement = Promise.promisifyAll(statement);
                 return queryStatement.setFetchSizeAsync(queryFetchSize);
             })
-            .then(function () {
+            .then(function() {
                 return queryStatement.executeQueryAsync(query);
             })
-            .then(function (resultSet) {
+            .then(function(resultSet) {
                 var asyncResultSet = Promise.promisifyAll(resultSet);
                 return asyncResultSet.toObjArrayAsync();
             })
-            .then(function (resultSetArray) {
-                if (verboseLoggingOn===true) {
+            .then(function(resultSetArray) {
+                if (verboseLoggingOn === true) {
                     console.log(resultSetArray);
                 }
                 return resultSetArray;
             })
     },
 
-    executePreparedStatement: function (query, args, fetchSize) {
+    executePreparedStatement: function(query, args, fetchSize) {
         var queryFetchSize = fetchSize ? fetchSize : DEFAULT_FETCH_SIZE;
         var queryStatement;
         return createPromisedPreparedStatement(query)
-            .then(function (statement) {
+            .then(function(statement) {
                 queryStatement = Promise.promisifyAll(statement);
                 return queryStatement.setFetchSizeAsync(queryFetchSize);
             })
-            .then(function () {
-                return Promise.all(args.map(function (arg, index) {
-                    switch (typeof arg) {
-                        case 'number':
-                            return queryStatement.setIntAsync(index + 1, arg);
-                        case 'string':
-                            return queryStatement.setStringAsync(index + 1, arg);
-                        default:
-                            throw(new Error('Invalid argument of type ' + typeof arg));
-                    }
-                }))
-                    .then(function () {
+            .then(function() {
+                return Promise.all(args.map(function(arg, index) {
+                        switch (typeof arg) {
+                            case 'number':
+                                return queryStatement.setIntAsync(index + 1, arg);
+                            case 'string':
+                                return queryStatement.setStringAsync(index + 1, arg);
+                            default:
+                                throw (new Error('Invalid argument of type ' + typeof arg));
+                        }
+                    }))
+                    .then(function() {
                         return queryStatement.executeQueryAsync();
                     });
             })
-            .then(function (resultSet) {
+            .then(function(resultSet) {
                 var asyncResultSet = Promise.promisifyAll(resultSet);
                 return asyncResultSet.toObjArrayAsync();
             })
-            .then(function (resultSetArray) {
+            .then(function(resultSetArray) {
                 return resultSetArray;
             });
     },
 
-    executeUpdate: function (query) {
+    executeUpdate: function(query) {
         var updateStatement;
         return createPromisedStatement(query)
-            .then(function (promisedStatement) {
+            .then(function(promisedStatement) {
                 return promisedStatement.executeUpdateAsync(query);
             })
-            .then(function (updateCount) {
+            .then(function(updateCount) {
                 return updateCount;
             })
     }


### PR DESCRIPTION
This enables users to specify JDBC connection options in the ‘connect’ method. The motivation for this change was being able to specify the connection pool size.

This entails addition of the `jdbcOptions` param to the `connect` method signature. 

Users can specify any connection options supported by _node-jdbc_ in the `jdbcOptions` object. These will be marshalled into the `teradataConfig` object in the connect method and passed to _node-jdbc_ when creating the teradata connection instance (`teradataInstance`).
